### PR TITLE
Rename env_config params `num_cues`, `num_due_pairs`, update defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,15 @@ The environment has the following configuration options:
 
 | Parameter | Description | Datatype | Default Value |
 |-----------|-------------|----------|---------------|
-| num_rbs | The number of available resource blocks. | `int` | 30 |
-| num_cellular_users | The number of cellular users. | `int`| 30 |
-| num_d2d_pairs | The number of D2D pairs | `int` | 12 |
+| num_rbs | The number of available resource blocks. | `int` | 25 |
+| num_cues | The number of cellular users. | `int`| 25 |
+| num_due_pairs | The number of D2D pairs | `int` | 25 |
 | cell_radius_m | The macro base station's cell radius in metres. This parameter controls the radius in which all other devices are contained. | `float` | 500.0 |
 | d2d_radius_m  | The maximum distance between D2D pairs in metres. | `float` | 20.0 |
-| cue_max_tx_power_dBm | The maximum CUE transmission power in dBm. This is a discrete value, from 0 to max. | `int` | 23 |
 | due_min_tx_power_dBm | The minimum DUE transmission power in dBm. | `int` | 0 |
-| due_max_tx_power_dBm | The maximum DUE transmission power in dBm. | `int` | 23 |
+| due_max_tx_power_dBm | The maximum DUE transmission power in dBm. | `int` | 20 |
+| cue_max_tx_power_dBm | The maximum CUE transmission power in dBm. | `int` | 23 |
+| mbs_max_tx_power_dBm | The maximum MBS transmission power in dBm. | `int` | 46 |
 | path_loss_model | The type of path loss model to use. | `gym_d2d.` `PathLoss` | `gym_d2d.` `LogDistancePathLoss` |
 | traffic_model | The model to generate automated traffic. | `gym_d2d.` `TrafficModel` | `gym_d2d.` `UplinkTrafficModel` |
 | obs_fn | The function to calculate agent observations. | `gym_d2d.envs.` `ObsFunction` | `gym_d2d.envs.` `Linear1ObsFunction` |

--- a/examples/plot_devices.py
+++ b/examples/plot_devices.py
@@ -12,8 +12,8 @@ from gym_d2d import plot_devices
 # create a new environment, optionally load a device configuration from file,
 # and use `reset()` to initialise the environment
 env_config = {
-    'num_cellular_users': 15,
-    'num_d2d_pairs': 15,
+    'num_cues': 15,
+    'num_due_pairs': 15,
     'cell_radius_m': 500.0,
     'd2d_radius_m': 50.0,
     # 'device_config_file': Path.cwd() / 'device_config.json'

--- a/src/gym_d2d/envs/d2d_env.py
+++ b/src/gym_d2d/envs/d2d_env.py
@@ -56,7 +56,7 @@ class D2DEnv(gym.Env):
         # create cellular UEs
         cues = {}
         default_cue_cfg = {**base_cfg, **{'max_tx_power_dBm': self.config.cue_max_tx_power_dBm}}
-        for i in range(self.config.num_cellular_users):
+        for i in range(self.config.num_cues):
             cue_id = Id(f'cue{i:02d}')
             config = self.config.devices[cue_id]['config'] if cue_id in self.config.devices else default_cue_cfg
             cues[cue_id] = UserEquipment(cue_id, config)
@@ -64,7 +64,7 @@ class D2DEnv(gym.Env):
         # create D2D UEs
         dues = {}
         due_cfg = {**base_cfg, **{'max_tx_power_dBm': self.config.due_max_tx_power_dBm}}
-        for i in range(0, (self.config.num_d2d_pairs * 2), 2):
+        for i in range(0, (self.config.num_due_pairs * 2), 2):
             due_tx_id, due_rx_id = Id(f'due{i:02d}'), Id(f'due{i + 1:02d}')
 
             due_tx_config = self.config.devices[due_tx_id]['config'] if due_tx_id in self.config.devices else due_cfg

--- a/src/gym_d2d/envs/env_config.py
+++ b/src/gym_d2d/envs/env_config.py
@@ -11,15 +11,15 @@ from gym_d2d.traffic_model import TrafficModel, UplinkTrafficModel
 
 @dataclass
 class EnvConfig:
-    num_rbs: int = 30
-    num_cellular_users: int = 30
-    num_d2d_pairs: int = 12
-    num_small_base_stations: int = 0
+    num_rbs: int = 25
+    num_cues: int = 25
+    num_due_pairs: int = 25
     cell_radius_m: float = 500.0
     d2d_radius_m: float = 20.0
-    cue_max_tx_power_dBm: int = 23
     due_min_tx_power_dBm: int = 0
-    due_max_tx_power_dBm: int = 23
+    due_max_tx_power_dBm: int = 20
+    cue_max_tx_power_dBm: int = 23
+    mbs_max_tx_power_dBm: int = 46
     path_loss_model: Type[PathLoss] = LogDistancePathLoss
     traffic_model: Type[TrafficModel] = UplinkTrafficModel
     carrier_freq_GHz: float = 2.1

--- a/src/gym_d2d/envs/obs_fn.py
+++ b/src/gym_d2d/envs/obs_fn.py
@@ -26,8 +26,8 @@ class ObsFunction(ABC):
 
 class Linear1ObsFunction(ObsFunction):
     def get_obs_space(self, env_config: dict) -> Space:
-        num_txs = env_config['num_cellular_users'] + env_config['num_d2d_pairs']
-        # num_rxs = 1 + self.num_d2d_pairs  # basestation + num D2D rxs
+        num_txs = env_config['num_cues'] + env_config['num_due_pairs']
+        # num_rxs = 1 + self.num_due_pairs  # basestation + num D2D rxs
         num_tx_obs = 5  # sinrs, tx_pwrs, rbs, xs, ys
         num_rx_obs = 2  # xs, ys
         # obs_shape = ((num_txs * num_tx_obs) + (num_rxs * num_rx_obs),)
@@ -55,7 +55,7 @@ class Linear1ObsFunction(ObsFunction):
 
 class Linear2ObsFunction(ObsFunction):
     def get_obs_space(self, env_config: dict) -> Space:
-        num_txs = env_config['num_cellular_users'] + env_config['num_d2d_pairs']
+        num_txs = env_config['num_cues'] + env_config['num_due_pairs']
         num_due_obs = 2  # x, y
         num_common_obs = 7  # tx_x, tx_y, rx_x, rx_y, tx_pwr, rb, sinr
         obs_shape = (num_due_obs + (num_common_obs * num_txs),)


### PR DESCRIPTION
Rename:
- `num_cellular_users` to `num_cues`
- `num_d2d_pairs` to `num_due_pairs`

Update default num_cues, num_due_pairs, num_rbs values to more sensible defaults

Remove unused `num_small_base_stations` env_config