### PR TITLE
Change Devices container to a Mapping from a dataclass

### DIFF
--- a/src/gym_d2d/envs/d2d_env.py
+++ b/src/gym_d2d/envs/d2d_env.py
@@ -67,7 +67,7 @@ class D2DEnv(gym.Env):
         self.config = EnvConfig(**env_config or {})
         self.devices = create_devices(self.config)
         self.simulator = Simulator(
-            self.devices.to_dict(),
+            self.devices,
             self.config.traffic_model(self.devices.bs, list(self.devices.cues.values()), self.config.num_rbs),
             self.config.path_loss_model(self.config.carrier_freq_GHz)
         )

--- a/src/gym_d2d/envs/devices.py
+++ b/src/gym_d2d/envs/devices.py
@@ -1,27 +1,34 @@
-from dataclasses import dataclass
+from collections.abc import Mapping
 from typing import Dict, Tuple
 
 from gym_d2d.device import Device, BaseStation, UserEquipment
 from gym_d2d.id import Id
 
 
-@dataclass
-class Devices:
-    bs: BaseStation
-    cues: Dict[Id, UserEquipment]
-    dues: Dict[Tuple[Id, Id], Tuple[UserEquipment, UserEquipment]]
+class Devices(Mapping):
+    def __init__(self,
+                 bs: BaseStation,
+                 cues: Dict[Id, UserEquipment],
+                 due_pairs: Dict[Tuple[Id, Id], Tuple[UserEquipment, UserEquipment]]
+                 ) -> None:
+        super().__init__()
+        self.bs: BaseStation = bs
+        self.cues: Dict[Id, UserEquipment] = cues
+        self.dues: Dict[Tuple[Id, Id], Tuple[UserEquipment, UserEquipment]] = due_pairs
+        self.due_pairs = {}
+        self.due_pairs_inv = {}
+        self._devices: Dict[Id, Device] = {bs.id: bs, **cues}
+        for (tx_id, rx_id), (tx, rx) in due_pairs.items():
+            self._devices[tx_id] = tx
+            self._devices[rx_id] = rx
+            self.due_pairs[tx_id] = rx_id
+            self.due_pairs_inv[rx_id] = tx_id
 
-    def __post_init__(self):
-        self.due_pairs = {tx_id: rx_id for tx_id, rx_id in self.dues.keys()}
-        self.due_pairs_inv = {rx_id: tx_id for tx_id, rx_id in self.dues.keys()}
+    def __getitem__(self, key):
+        return self._devices[key]
 
-    def to_dict(self) -> Dict[Id, Device]:
-        dues = {}
-        for (tx_id, rx_id), (tx, rx) in self.dues.items():
-            dues[tx_id] = tx
-            dues[rx_id] = rx
-        return {
-            self.bs.id: self.bs,
-            **self.cues,
-            **dues
-        }
+    def __len__(self):
+        return len(self._devices)
+
+    def __iter__(self):
+        return iter(self._devices)

--- a/src/gym_d2d/simulator.py
+++ b/src/gym_d2d/simulator.py
@@ -5,16 +5,16 @@ from typing import Dict, Tuple
 from .action import Action
 from .channel import Channel
 from .conversion import dB_to_linear, linear_to_dB
-from .device import Device
+from .envs.devices import Devices
 from .id import Id
 from .path_loss import PathLoss
 from .traffic_model import TrafficModel
 
 
 class Simulator:
-    def __init__(self, devices: Dict[Id, Device], traffic_model: TrafficModel, path_loss: PathLoss) -> None:
+    def __init__(self, devices: Devices, traffic_model: TrafficModel, path_loss: PathLoss) -> None:
         super().__init__()
-        self.devices: Dict[Id, Device] = devices
+        self.devices: Devices = devices
         self.traffic_model: TrafficModel = traffic_model
         self.path_loss: PathLoss = path_loss
         self.channels: Dict[Tuple[Id, Id], Channel] = {}


### PR DESCRIPTION
Step 1 of refactoring out the devices reference in the env, change the `Devices` container to a custom mapping to support both selection via bs/cue/due type and selection via id