### PR TITLE
Remove Devices container out of Env and only in Simulator

### DIFF
--- a/src/gym_d2d/envs/d2d_env.py
+++ b/src/gym_d2d/envs/d2d_env.py
@@ -65,19 +65,18 @@ class D2DEnv(gym.Env):
     def __init__(self, env_config=None) -> None:
         super().__init__()
         self.config = EnvConfig(**env_config or {})
-        self.devices = create_devices(self.config)
+        devices = create_devices(self.config)
         self.simulator = Simulator(
-            self.devices,
-            self.config.traffic_model(self.devices.bs, list(self.devices.cues.values()), self.config.num_rbs),
+            devices,
+            self.config.traffic_model(devices.bs, list(devices.cues.values()), self.config.num_rbs),
             self.config.path_loss_model(self.config.carrier_freq_GHz)
         )
-
-        self.obs_fn = self.config.obs_fn(self.simulator, self.devices)
+        self.obs_fn = self.config.obs_fn(self.simulator)
         self.observation_space = self.obs_fn.get_obs_space(self.config.__dict__)
         # +1 because include max value, i.e. from [0, ..., max]
         num_tx_pwr_actions = self.config.due_max_tx_power_dBm - self.config.due_min_tx_power_dBm + 1
         self.action_space = spaces.Discrete(self.config.num_rbs * num_tx_pwr_actions)
-        self.reward_fn = self.config.reward_fn(self.simulator, self.devices)
+        self.reward_fn = self.config.reward_fn(self.simulator)
         self.num_steps = 0
 
     def reset(self):
@@ -87,10 +86,10 @@ class D2DEnv(gym.Env):
                 pos = Position(0, 0)  # assume MBS fixed at (0,0) and everything else builds around it
             elif device.id in self.config.devices:
                 pos = Position(*self.config.devices[device.id]['position'])
-            elif any(device.id in d for d in [self.devices.cues, self.devices.due_pairs]):
+            elif any(device.id in d for d in [self.simulator.devices.cues, self.simulator.devices.due_pairs]):
                 pos = get_random_position(self.config.cell_radius_m)
-            elif device.id in self.devices.due_pairs_inv:
-                due_tx_id = self.devices.due_pairs_inv[device.id]
+            elif device.id in self.simulator.devices.due_pairs_inv:
+                due_tx_id = self.simulator.devices.due_pairs_inv[device.id]
                 due_tx = self.simulator.devices[due_tx_id]
                 pos = get_random_position_nearby(self.config.cell_radius_m, due_tx.position, self.config.d2d_radius_m)
             else:
@@ -100,7 +99,7 @@ class D2DEnv(gym.Env):
         self.simulator.reset()
         # take a step with random D2D actions to generate initial SINRs
         random_actions = {due_id: self._extract_action(due_id, self.action_space.sample())
-                          for due_id in self.devices.due_pairs.keys()}
+                          for due_id in self.simulator.devices.due_pairs.keys()}
         results = self.simulator.step(random_actions)
         obs = self.obs_fn.get_state(results)
         return obs
@@ -122,7 +121,7 @@ class D2DEnv(gym.Env):
     def _extract_action(self, due_tx_id: Id, action: int) -> Action:
         rb = action % self.config.num_rbs
         tx_pwr_dBm = (action // self.config.num_rbs) + self.config.due_min_tx_power_dBm
-        return Action(due_tx_id, self.devices.due_pairs[due_tx_id], LinkType.SIDELINK, rb, tx_pwr_dBm)
+        return Action(due_tx_id, self.simulator.devices.due_pairs[due_tx_id], LinkType.SIDELINK, rb, tx_pwr_dBm)
 
     def _info(self, actions: Dict[Id, Action], results: dict):
         info = {}
@@ -133,7 +132,7 @@ class D2DEnv(gym.Env):
             sum_system_sinr += sinr_db
             sum_system_rate_bps += results['rate_bps'][(tx_id, rx_id)]
             sum_system_capacity += capacity
-            if tx_id in self.devices.due_pairs:
+            if tx_id in self.simulator.devices.due_pairs:
                 info[tx_id] = {
                     'rb': actions[tx_id].rb,
                     'tx_pwr_dbm': actions[tx_id].tx_pwr_dBm,
@@ -149,8 +148,9 @@ class D2DEnv(gym.Env):
                 sum_cue_capacity += capacity
 
         aggregate_info = {
-            'env_mean_cue_sinr_db': sum_cue_sinr / len(self.devices.cues),
-            'env_mean_system_sinr_db': sum_system_sinr / (len(self.devices.cues) + len(self.devices.due_pairs)),
+            'env_mean_cue_sinr_db': sum_cue_sinr / len(self.simulator.devices.cues),
+            'env_mean_system_sinr_db':
+                sum_system_sinr / (len(self.simulator.devices.cues) + len(self.simulator.devices.due_pairs)),
             'env_sum_cue_rate_bps': sum_cue_rate_bps,
             'env_sum_due_rate_bps': sum_due_rate_bps,
             'env_sum_system_rate_bps': sum_system_rate_bps,

--- a/src/gym_d2d/envs/obs_fn.py
+++ b/src/gym_d2d/envs/obs_fn.py
@@ -4,16 +4,14 @@ from typing import Dict
 from gym import Space, spaces
 import numpy as np
 
-from .devices import Devices
 from gym_d2d.id import Id
 from gym_d2d.simulator import Simulator
 
 
 class ObsFunction(ABC):
-    def __init__(self, simulator: Simulator, devices: Devices) -> None:
+    def __init__(self, simulator: Simulator) -> None:
         super().__init__()
         self.simulator: Simulator = simulator
-        self.devices: Devices = devices
 
     @abstractmethod
     def get_obs_space(self, env_config: dict) -> Space:
@@ -50,7 +48,7 @@ class Linear1ObsFunction(ObsFunction):
         common_obs.extend(rbs)
         common_obs.extend(positions)
 
-        return {due_id: np.array(common_obs) for due_id in self.devices.due_pairs.keys()}
+        return {due_id: np.array(common_obs) for due_id in self.simulator.devices.due_pairs.keys()}
 
 
 class Linear2ObsFunction(ObsFunction):
@@ -71,7 +69,7 @@ class Linear2ObsFunction(ObsFunction):
             common_obs.append(results['sinrs_db'][(channel.tx.id, channel.rx.id)])
 
         obs_dict = {}
-        for due_id in self.devices.due_pairs.keys():
+        for due_id in self.simulator.devices.due_pairs.keys():
             due_pos = list(self.simulator.devices[due_id].position.as_tuple())
             due_obs = []
             due_obs.extend(due_pos)

--- a/src/gym_d2d/envs/reward_fn.py
+++ b/src/gym_d2d/envs/reward_fn.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 from math import log2
 from typing import Dict
 
-from .devices import Devices
 from gym_d2d.id import Id
 from gym_d2d.simulator import Simulator
 from gym_d2d.conversion import dB_to_linear
@@ -11,10 +10,9 @@ from gym_d2d.link_type import LinkType
 
 
 class RewardFunction(ABC):
-    def __init__(self, simulator: Simulator, devices: Devices) -> None:
+    def __init__(self, simulator: Simulator) -> None:
         super().__init__()
         self.simulator: Simulator = simulator
-        self.devices: Devices = devices
 
     @abstractmethod
     def __call__(self, results: dict) -> Dict[Id, float]:
@@ -30,32 +28,32 @@ class SystemCapacityRewardFunction(RewardFunction):
 
         reward = -1
         _break = False
-        for tx_id, rx_id in self.devices.due_pairs.items():
+        for tx_id, rx_id in self.simulator.devices.due_pairs.items():
             if _break:
                 break
             rb = self.simulator.channels[(tx_id, rx_id)].rb
             ix_channels = rbs[rb].difference({(tx_id, rx_id)})
             for ix_tx_id, ix_rx_id in ix_channels:
-                if ix_tx_id in self.devices.due_pairs:
+                if ix_tx_id in self.simulator.devices.due_pairs:
                     continue
                 if results['capacity_mbps'][(ix_tx_id, ix_rx_id)] <= 0:
                     _break = True
                     break
         else:
             sum_capacity = sum(results['capacity_mbps'].values())
-            reward = sum_capacity / len(self.devices.due_pairs)
+            reward = sum_capacity / len(self.simulator.devices.due_pairs)
 
-        return {tx_id: reward for tx_id in self.devices.due_pairs.keys()}
+        return {tx_id: reward for tx_id in self.simulator.devices.due_pairs.keys()}
 
 
 class DueShannonRewardFunction(RewardFunction):
-    def __init__(self, simulator: Simulator, devices: Devices) -> None:
-        super().__init__(simulator, devices)
+    def __init__(self, simulator: Simulator) -> None:
+        super().__init__(simulator)
         self.min_sinr = -70.0
 
     def __call__(self, results: dict) -> Dict[Id, float]:
         rewards = {}
-        for tx_id, rx_id in self.devices.due_pairs.items():
+        for tx_id, rx_id in self.simulator.devices.due_pairs.items():
             sinr = results['sinrs_db'][(tx_id, rx_id)]
             if sinr >= self.min_sinr:
                 rewards[tx_id] = log2(1 + dB_to_linear(sinr))
@@ -65,8 +63,8 @@ class DueShannonRewardFunction(RewardFunction):
 
 
 class CueSinrShannonRewardFunction(RewardFunction):
-    def __init__(self, simulator: Simulator, devices: Devices, sinr_threshold_dB=0.0) -> None:
-        super().__init__(simulator, devices)
+    def __init__(self, simulator: Simulator, sinr_threshold_dB=0.0) -> None:
+        super().__init__(simulator)
         self.sinr_threshold_dB: float = float(sinr_threshold_dB)
 
     def __call__(self, results: dict) -> Dict[Id, float]:
@@ -76,7 +74,7 @@ class CueSinrShannonRewardFunction(RewardFunction):
             rbs[channel.rb].add(channel)
 
         rewards = {}
-        for tx_id, rx_id in self.devices.due_pairs.items():
+        for tx_id, rx_id in self.simulator.devices.due_pairs.items():
             channel = self.simulator.channels[(tx_id, rx_id)]
             ix_channels = rbs[channel.rb].difference({channel})
             rewards[tx_id] = -1

--- a/src/gym_d2d/utils.py
+++ b/src/gym_d2d/utils.py
@@ -23,12 +23,12 @@ def plot_devices(env, out_file: str = ''):
         raise ImportError('`plot_devices()` requires matplotlib')
 
     cue_xs, cue_ys = [], []
-    for cue_id, cue in env.devices.cues.items():
+    for cue_id, cue in env.simulator.devices.cues.items():
         cue_xs.append(cue.position.x)
         cue_ys.append(cue.position.y)
     due_tx_xs, due_tx_ys = [], []
     due_rx_xs, due_rx_ys = [], []
-    for due_tx_id, due_rx_id in env.devices.due_pairs.items():
+    for due_tx_id, due_rx_id in env.simulator.devices.due_pairs.items():
         due_tx = env.simulator.devices[due_tx_id]
         due_tx_xs.append(due_tx.position.x)
         due_tx_ys.append(due_tx.position.y)
@@ -37,7 +37,7 @@ def plot_devices(env, out_file: str = ''):
         due_rx_ys.append(due_rx.position.y)
     fig = plt.figure()
     ax = fig.add_subplot(111)
-    mbs_pos = env.devices.bs.position
+    mbs_pos = env.simulator.devices.bs.position
     ax.add_artist(plt.Circle(mbs_pos.as_tuple(), env.config.cell_radius_m, color='b', alpha=0.1))
     ax.scatter(due_tx_xs, due_tx_ys, c='r', label='DUE_TX')
     ax.scatter(due_rx_xs, due_rx_ys, c='m', label='DUE_RX')


### PR DESCRIPTION
Follows on from prev PR. Remove all references to devices container in Env, so only in Simulator. 