### PR TITLE
Fix `env.render()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ It is highly configurable, allowing users to experiment with UE configuration, p
 
 GymD2D models a D2D cellular offload scenario containing a single macro base station surrounded with many cellular (CUE) and D2D (DUE) user equipment. 
 
-This project is still under active development and we haven't finished the first stable release yet.
-_Some functionality, such as `env.render()` are not currently working._
+This project is still under active development and the API hasn't stabilised yet. 
+Breaking changes are likely to occur between releases.
 
 If you have found this project useful in your research, please consider citing our [white paper](https://arxiv.org/abs/2101.11188) (preprint, forthcoming at [IEEE WCNC 2021](https://wcnc2021.ieee-wcnc.org/)).
 ```bibtex

--- a/examples/simple_env.py
+++ b/examples/simple_env.py
@@ -30,5 +30,4 @@ for _ in range(10):
         actions_dict[agent_id] = action
 
     obses, rewards_dict, game_over, info = env.step(actions_dict)
-    # env.render()
-    print(obses)
+    env.render()

--- a/src/gym_d2d/envs/obs_fn.py
+++ b/src/gym_d2d/envs/obs_fn.py
@@ -18,7 +18,7 @@ class ObsFunction(ABC):
         pass
 
     @abstractmethod
-    def get_state(self, results: dict) -> Dict[Id, np.array]:
+    def get_state(self, state: dict) -> Dict[Id, np.array]:
         pass
 
 
@@ -30,12 +30,12 @@ class LinearObsFunction(ObsFunction):
         obs_shape = (num_obs * num_txs,)
         return spaces.Box(low=-r, high=r, shape=obs_shape)
 
-    def get_state(self, results: dict) -> Dict[Id, np.array]:
+    def get_state(self, state: dict) -> Dict[Id, np.array]:
         obses = {}
         for (tx_id, rx_id), channel in self.simulator.channels.items():
             obses[tx_id] = list(channel.tx.position.as_tuple() + channel.rx.position.as_tuple())
-            obses[tx_id].append(results['sinrs_db'][(tx_id, rx_id)])
-            obses[tx_id].append(results['snrs_db'][(tx_id, rx_id)])
+            obses[tx_id].append(state['sinrs_db'][(tx_id, rx_id)])
+            obses[tx_id].append(state['snrs_db'][(tx_id, rx_id)])
 
         obs_dict = {}
         for tx_id in obses:


### PR DESCRIPTION
- Fix `env.render()` by saving simulator state to instance var in env
- Also rename `results` to less confusing `state`