### PR TITLE
Simplify construction of TrafficModels

### DIFF
--- a/src/gym_d2d/simulator.py
+++ b/src/gym_d2d/simulator.py
@@ -62,11 +62,7 @@ class Simulator:
         super().__init__()
         self.config = EnvConfig(**env_config)
         self.devices: Devices = create_devices(self.config)
-        self.traffic_model: TrafficModel = self.config.traffic_model(
-            self.devices.bs,
-            list(self.devices.cues.values()),
-            self.config.num_rbs
-        )
+        self.traffic_model: TrafficModel = self.config.traffic_model(self.config.num_rbs)
         self.path_loss: PathLoss = self.config.path_loss_model(self.config.carrier_freq_GHz)
         self.channels: Dict[Tuple[Id, Id], Channel] = {}
 
@@ -102,7 +98,7 @@ class Simulator:
 
     def _generate_traffic(self, actions: Dict[Id, Action]) -> None:
         # automated traffic
-        # self.channels = self.traffic_model.get_traffic()
+        # self.channels = self.traffic_model.get_traffic(self.devices)
         # supplied actions
         for action in actions.values():
             tx, rx = self.devices[action.tx_id], self.devices[action.rx_id]

--- a/src/gym_d2d/traffic_model.py
+++ b/src/gym_d2d/traffic_model.py
@@ -1,37 +1,35 @@
-from typing import Dict, List, Tuple
+from typing import Dict, Tuple
 
 from .channel import Channel
-from .device import BaseStation, UserEquipment
+from .envs.devices import Devices
 from .id import Id
 from .link_type import LinkType
 
 
 class TrafficModel:
-    def __init__(self, bs: BaseStation, ues: List[UserEquipment], num_rbs: int) -> None:
+    def __init__(self, num_rbs: int) -> None:
         super().__init__()
-        self.bs: BaseStation = bs
-        self.ues: List[UserEquipment] = ues
         self.num_rbs: int = num_rbs
 
-    def get_traffic(self) -> Dict[Tuple[Id, Id], Channel]:
+    def get_traffic(self, devices: Devices) -> Dict[Tuple[Id, Id], Channel]:
         pass
 
 
 class UplinkTrafficModel(TrafficModel):
-    def get_traffic(self) -> Dict[Tuple[Id, Id], Channel]:
+    def get_traffic(self, devices: Devices) -> Dict[Tuple[Id, Id], Channel]:
         rb = 0
         traffic = {}
-        for ue in self.ues:
-            traffic[(ue.id, self.bs.id)] = Channel(ue, self.bs, LinkType.UPLINK, rb, ue.max_tx_power_dBm)
+        for cue_id, cue in devices.cues.items():
+            traffic[(cue_id, devices.bs.id)] = Channel(cue, devices.bs, LinkType.UPLINK, rb, cue.max_tx_power_dBm)
             rb = (rb + 1) % self.num_rbs
         return traffic
 
 
 class DownlinkTrafficModel(TrafficModel):
-    def get_traffic(self) -> Dict[Tuple[Id, Id], Channel]:
+    def get_traffic(self, devices: Devices) -> Dict[Tuple[Id, Id], Channel]:
         rb = 0
         traffic = {}
-        for ue in self.ues:
-            traffic[(self.bs.id, ue.id)] = Channel(self.bs, ue, LinkType.DOWNLINK, rb, ue.max_tx_power_dBm)
+        for cue_id, cue in devices.cues.items():
+            traffic[(devices.bs.id, cue_id)] = Channel(devices.bs, cue, LinkType.DOWNLINK, rb, cue.max_tx_power_dBm)
             rb = (rb + 1) % self.num_rbs
         return traffic


### PR DESCRIPTION
Simplify construction of TrafficModels by using the simulator's devices container. This should provide more flexibility in the future with different Devices containers