### PR TITLE
Env config fix

### DIFF
--- a/src/gym_d2d/envs/d2d_env.py
+++ b/src/gym_d2d/envs/d2d_env.py
@@ -7,12 +7,16 @@ from gym import spaces
 import numpy as np
 
 from gym_d2d.action import Action
+from gym_d2d.envs.obs_fn import LinearObsFunction
+from gym_d2d.envs.reward_fn import SystemCapacityRewardFunction
 from gym_d2d.id import Id
 from gym_d2d.link_type import LinkType
 from gym_d2d.simulator import Simulator
 
 
 EPISODE_LENGTH = 10
+DEFAULT_OBS_FN = LinearObsFunction
+DEFAULT_REWARD_FN = SystemCapacityRewardFunction
 
 
 class D2DEnv(gym.Env):
@@ -20,9 +24,10 @@ class D2DEnv(gym.Env):
 
     def __init__(self, env_config=None) -> None:
         super().__init__()
-        self.simulator = Simulator(env_config or {})
-        self.obs_fn = self.simulator.config.obs_fn()
-        self.observation_space = self.obs_fn.get_obs_space(self.simulator.config.__dict__)
+        env_config = env_config or {}
+        self.simulator = Simulator(env_config)
+        self.obs_fn = env_config.get('obs_fn', DEFAULT_OBS_FN)()
+        self.observation_space = self.obs_fn.get_obs_space(self.simulator.config)
         self.num_pwr_actions = {  # +1 because include max value, i.e. from [0, ..., max]
             'due': self.simulator.config.due_max_tx_power_dBm - self.simulator.config.due_min_tx_power_dBm + 1,
             'cue': self.simulator.config.cue_max_tx_power_dBm + 1,
@@ -33,7 +38,7 @@ class D2DEnv(gym.Env):
             'cue': spaces.Discrete(self.simulator.config.num_rbs * self.num_pwr_actions['cue']),
             'mbs': spaces.Discrete(self.simulator.config.num_rbs * self.num_pwr_actions['mbs']),
         })
-        self.reward_fn = self.simulator.config.reward_fn()
+        self.reward_fn = env_config.get('reward_fn', DEFAULT_REWARD_FN)()
         self.state = None
         self.num_steps = 0
 

--- a/src/gym_d2d/envs/env_config.py
+++ b/src/gym_d2d/envs/env_config.py
@@ -24,7 +24,6 @@ class EnvConfig:
     num_subcarriers: int = 12
     subcarrier_spacing_kHz: int = 15
     channel_bandwidth_MHz: float = 20.0
-    compressed_info: bool = False
     device_config_file: Optional[Path] = None
 
     def __post_init__(self):

--- a/src/gym_d2d/envs/env_config.py
+++ b/src/gym_d2d/envs/env_config.py
@@ -3,8 +3,6 @@ import json
 from pathlib import Path
 from typing import Optional, Type
 
-from .obs_fn import ObsFunction, LinearObsFunction
-from .reward_fn import RewardFunction, SystemCapacityRewardFunction
 from gym_d2d.path_loss import PathLoss, LogDistancePathLoss
 from gym_d2d.traffic_model import TrafficModel, UplinkTrafficModel
 
@@ -26,8 +24,6 @@ class EnvConfig:
     num_subcarriers: int = 12
     subcarrier_spacing_kHz: int = 15
     channel_bandwidth_MHz: float = 20.0
-    obs_fn: Type[ObsFunction] = LinearObsFunction
-    reward_fn: Type[RewardFunction] = SystemCapacityRewardFunction
     compressed_info: bool = False
     device_config_file: Optional[Path] = None
 

--- a/src/gym_d2d/envs/obs_fn.py
+++ b/src/gym_d2d/envs/obs_fn.py
@@ -6,12 +6,13 @@ import numpy as np
 
 from gym_d2d.channel import Channel
 from gym_d2d.envs.devices import Devices
+from gym_d2d.envs.env_config import EnvConfig
 from gym_d2d.id import Id
 
 
 class ObsFunction(ABC):
     @abstractmethod
-    def get_obs_space(self, env_config: dict) -> Space:
+    def get_obs_space(self, env_config: EnvConfig) -> Space:
         pass
 
     @abstractmethod
@@ -20,9 +21,9 @@ class ObsFunction(ABC):
 
 
 class LinearObsFunction(ObsFunction):
-    def get_obs_space(self, env_config: dict) -> Space:
-        r = env_config['cell_radius_m']
-        num_txs = env_config['num_cues'] + env_config['num_due_pairs']
+    def get_obs_space(self, env_config: EnvConfig) -> Space:
+        r = env_config.cell_radius_m
+        num_txs = env_config.num_cues + env_config.num_due_pairs
         num_obs = 6  # tx_x, tx_y, rx_x, rx_y, sinr, snr
         obs_shape = (num_obs * num_txs,)
         return spaces.Box(low=-r, high=r, shape=obs_shape)


### PR DESCRIPTION
- Remove Obs & Reward fns from EnvConfig. This fixes a circular dependency issue between Obs/Reward fns & EnvConfig and allows the actual EnvConfig to be injected into Obs/Reward fns instead of a dict copy
- Also remove unused, older EnvConfig.compressed_info var