### PR TITLE
Use tx-rx ID pairs as dict keys

### DIFF
--- a/src/gym_d2d/envs/obs_fn.py
+++ b/src/gym_d2d/envs/obs_fn.py
@@ -7,7 +7,6 @@ import numpy as np
 from gym_d2d.channels import Channels
 from gym_d2d.devices import Devices
 from gym_d2d.envs.env_config import EnvConfig
-from gym_d2d.id import Id
 
 
 class ObsFunction(ABC):
@@ -16,7 +15,7 @@ class ObsFunction(ABC):
         pass
 
     @abstractmethod
-    def get_state(self, state: dict, channels: Channels, devices: Devices) -> Dict[Id, np.array]:
+    def get_state(self, state: dict, channels: Channels, devices: Devices) -> Dict[str, np.array]:
         pass
 
 
@@ -28,19 +27,19 @@ class LinearObsFunction(ObsFunction):
         obs_shape = (num_obs * num_txs,)
         return spaces.Box(low=-r, high=r, shape=obs_shape)
 
-    def get_state(self, state: dict, channels: Channels, devices: Devices) -> Dict[Id, np.array]:
+    def get_state(self, state: dict, channels: Channels, devices: Devices) -> Dict[str, np.array]:
         agent_obs = {}
-        for (tx_id, rx_id), channel in channels.items():
-            agent_obs[tx_id] = list(channel.tx.position.as_tuple() + channel.rx.position.as_tuple())
-            agent_obs[tx_id].append(state['sinrs_db'][(tx_id, rx_id)])
-            agent_obs[tx_id].append(state['snrs_db'][(tx_id, rx_id)])
+        for tx_rx_id, channel in channels.items():
+            agent_obs[tx_rx_id] = list(channel.tx.position.as_tuple() + channel.rx.position.as_tuple())
+            agent_obs[tx_rx_id].append(state['sinrs_db'][tx_rx_id])
+            agent_obs[tx_rx_id].append(state['snrs_db'][tx_rx_id])
 
         obses = {}
-        for tx_id in agent_obs:
-            tx_obs_copy = agent_obs[tx_id][:]
-            for other_tx_id, other_obs in agent_obs.items():
-                if other_tx_id != tx_id:
+        for tx_rx_id in agent_obs:
+            tx_obs_copy = agent_obs[tx_rx_id][:]
+            for other_tx_rx_id, other_obs in agent_obs.items():
+                if other_tx_rx_id != tx_rx_id:
                     tx_obs_copy.extend(other_obs)
-            obses[tx_id] = np.array(tx_obs_copy)
+            obses[':'.join(tx_rx_id)] = np.array(tx_obs_copy)
 
         return obses

--- a/src/gym_d2d/simulator.py
+++ b/src/gym_d2d/simulator.py
@@ -14,7 +14,7 @@ from .position import get_random_position_nearby, get_random_position, Position
 from .traffic_model import TrafficModel
 
 
-BASE_STATION_ID = 'mbs'
+BASE_STATION_ID = Id('mbs')
 
 
 def create_devices(config: EnvConfig) -> Devices:
@@ -83,7 +83,7 @@ class Simulator:
             device.set_position(pos)
         self.channels.clear()
 
-    def step(self, actions: Dict[Id, Action]) -> dict:
+    def step(self, actions: Dict[Tuple[Id, Id], Action]) -> dict:
         self._generate_traffic(actions)
         sinrs_db = self._calculate_sinrs()
         capacities = self._calculate_network_capacity(sinrs_db)
@@ -95,13 +95,13 @@ class Simulator:
             'capacity_mbps': capacities,
         }
 
-    def _generate_traffic(self, actions: Dict[Id, Action]) -> None:
+    def _generate_traffic(self, actions: Dict[Tuple[Id, Id], Action]) -> None:
         # automated traffic
         # self.channels = self.traffic_model.get_traffic(self.devices)
         # supplied actions
-        for action in actions.values():
-            tx, rx = self.devices[action.tx_id], self.devices[action.rx_id]
-            self.channels[(tx.id, rx.id)] = Channel(tx, rx, action.mode, action.rb, action.tx_pwr_dBm)
+        for tx_rx_id, action in actions.items():
+            tx, rx = self.devices[tx_rx_id[0]], self.devices[tx_rx_id[1]]
+            self.channels[tx_rx_id] = Channel(tx, rx, action.mode, action.rb, action.tx_pwr_dBm)
 
     def _calculate_sinrs(self) -> Dict[Tuple[Id, Id], float]:
         sinrs_db = {}


### PR DESCRIPTION
Use tx-rx ID pairs as dict keys. Previously only used tx_id to communicate to outside of Env. This change will enable fixes for downlink with external CUEs and to remove reset random actions in future PRs